### PR TITLE
Add support for more of the Papertrail API

### DIFF
--- a/bin/papertrail-add-group
+++ b/bin/papertrail-add-group
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+require 'papertrail/cli_add_group'
+
+begin
+  Papertrail::CliAddGroup.new.run
+rescue Interrupt
+  exit(0)
+end

--- a/bin/papertrail-add-system
+++ b/bin/papertrail-add-system
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+require 'papertrail/cli_add_system'
+
+begin
+  Papertrail::CliAddSystem.new.run
+rescue Interrupt
+  exit(0)
+end

--- a/bin/papertrail-join-group
+++ b/bin/papertrail-join-group
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+require 'papertrail/cli_join_group'
+
+begin
+  Papertrail::CliJoinGroup.new.run
+rescue Interrupt
+  exit(0)
+end

--- a/bin/papertrail-remove-system
+++ b/bin/papertrail-remove-system
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+require 'papertrail/cli_remove_system'
+
+begin
+  Papertrail::CliRemoveSystem.new.run
+rescue Interrupt
+  exit(0)
+end

--- a/lib/papertrail/cli_add_group.rb
+++ b/lib/papertrail/cli_add_group.rb
@@ -1,0 +1,77 @@
+require 'optparse'
+require 'yaml'
+
+require 'papertrail/cli'
+require 'papertrail/connection'
+
+module Papertrail
+  class CliAddGroup<Cli
+    def run
+      # Let it slide if we have invalid JSON
+      if JSON.respond_to?(:default_options)
+        JSON.default_options[:check_utf8] = false
+      end
+
+      options = {
+        :configfile => nil,
+      }
+
+      if configfile = find_configfile
+        configfile_options = load_configfile(configfile)
+        options.merge!(configfile_options)
+      end
+
+      OptionParser.new do |opts|
+        opts.banner = "papertrail-add-group"
+
+        opts.on("-h", "--help", "Show usage") do |v|
+          puts opts
+          exit
+        end
+        opts.on("-c", "--configfile PATH", "Path to config (~/.papertrail.yml)") do |v|
+          options[:configfile] = File.expand_path(v)
+        end
+        opts.on("-g", "--group SYSTEM", "Name of group to add") do |v|
+          options[:group] = v
+        end
+        opts.on("-w", "--system-wildcard WILDCARD", "Wildcard for system match") do |v|
+          options[:wildcard] = v
+        end
+
+        opts.separator usage
+      end.parse!
+
+      if options[:configfile]
+        configfile_options = load_configfile(options[:configfile])
+        options.merge!(configfile_options)
+      end
+
+      raise OptionParser::MissingArgument if options[:group].nil?
+
+      connection = Papertrail::Connection.new(options)
+
+      # Bail if group already exists
+      if connection.show_group(options[:group])
+        exit 0
+      end
+
+      if connection.create_group(options[:group], options[:wildcard])
+        exit 0
+      end
+
+      exit 1
+    end
+
+    def usage
+      <<-EOF
+
+  Usage: 
+    papertrail-add-group [-g group] [-w system-wildcard] [-c papertrail.yml] 
+
+  Example:
+    papertrail-add-group -g mygroup -w mygroup-systems*
+
+  EOF
+    end
+  end
+end

--- a/lib/papertrail/cli_add_system.rb
+++ b/lib/papertrail/cli_add_system.rb
@@ -1,0 +1,78 @@
+require 'optparse'
+require 'yaml'
+
+require 'papertrail/cli'
+require 'papertrail/connection'
+
+module Papertrail
+  class CliAddSystem<Cli
+    def run
+      # Let it slide if we have invalid JSON
+      if JSON.respond_to?(:default_options)
+        JSON.default_options[:check_utf8] = false
+      end
+
+      options = {
+        :configfile => nil,
+      }
+
+      if configfile = find_configfile
+        configfile_options = load_configfile(configfile)
+        options.merge!(configfile_options)
+      end
+
+      OptionParser.new do |opts|
+        opts.banner = "papertrail-add-system"
+
+        opts.on("-h", "--help", "Show usage") do |v|
+          puts opts
+          exit
+        end
+        opts.on("-c", "--configfile PATH", "Path to config (~/.papertrail.yml)") do |v|
+          options[:configfile] = File.expand_path(v)
+        end
+        opts.on("-s", "--system SYSTEM", "Name of system to add") do |v|
+          options[:system] = v
+        end
+        opts.on("-i", "--ip-address IP_ADDRESS", "IP address of system") do |v|
+          options[:ip] = v
+        end
+
+        opts.separator usage
+      end.parse!
+
+      if options[:configfile]
+        configfile_options = load_configfile(options[:configfile])
+        options.merge!(configfile_options)
+      end
+
+      raise OptionParser::MissingArgument if options[:system].nil?
+      raise OptionParser::MissingArgument if options[:ip].nil?
+
+      connection = Papertrail::Connection.new(options)
+      
+      # Bail if system already exists
+      if connection.show_source(options[:system])
+        exit 0
+      end
+
+      if connection.register_source(options[:system], options[:ip])
+        exit 0
+      end
+
+      exit 1
+    end
+
+    def usage
+      <<-EOF
+
+  Usage: 
+    papertrail-add-system [-s system] [-i ip-address] [-c papertrail.yml] 
+
+  Example:
+    papertrail-add-system -s mysystemname -i 1.2.3.4
+
+  EOF
+    end
+  end
+end

--- a/lib/papertrail/cli_join_group.rb
+++ b/lib/papertrail/cli_join_group.rb
@@ -1,0 +1,73 @@
+require 'optparse'
+require 'yaml'
+
+require 'papertrail/cli'
+require 'papertrail/connection'
+
+module Papertrail
+  class CliJoinGroup<Cli
+    def run
+      # Let it slide if we have invalid JSON
+      if JSON.respond_to?(:default_options)
+        JSON.default_options[:check_utf8] = false
+      end
+
+      options = {
+        :configfile => nil,
+      }
+
+      if configfile = find_configfile
+        configfile_options = load_configfile(configfile)
+        options.merge!(configfile_options)
+      end
+
+      OptionParser.new do |opts|
+        opts.banner = "papertrail-join-group"
+
+        opts.on("-h", "--help", "Show usage") do |v|
+          puts opts
+          exit
+        end
+        opts.on("-c", "--configfile PATH", "Path to config (~/.papertrail.yml)") do |v|
+          options[:configfile] = File.expand_path(v)
+        end
+        opts.on("-s", "--system SYSTEM", "Name of system to add to group") do |v|
+          options[:system] = v
+        end
+        opts.on("-g", "--group GROUP", "Name of group to join") do |v|
+          options[:group] = v
+        end
+
+        opts.separator usage
+      end.parse!
+
+      if options[:configfile]
+        configfile_options = load_configfile(options[:configfile])
+        options.merge!(configfile_options)
+      end
+
+      raise OptionParser::MissingArgument if options[:system].nil?
+      raise OptionParser::MissingArgument if options[:group].nil?
+
+      connection = Papertrail::Connection.new(options)
+
+      if connection.join_group(options[:system], options[:group])
+        exit 0
+      end
+
+      exit 1
+    end
+
+    def usage
+      <<-EOF
+
+  Usage: 
+    papertrail-join-group [-s system] [-g group] [-c papertrail.yml] 
+
+  Example:
+    papertrail-join-group -s mymachine -g mygroup
+
+  EOF
+    end
+  end
+end

--- a/lib/papertrail/connection.rb
+++ b/lib/papertrail/connection.rb
@@ -1,3 +1,4 @@
+require 'addressable/uri'
 require 'faraday'
 require 'openssl'
 require 'faraday_middleware'
@@ -11,9 +12,13 @@ module Papertrail
 
     attr_reader :connection
 
-    def_delegators :@connection, :get, :put, :post
+    def_delegators :@connection, :get, :put, :post, :delete
 
     def initialize(options)
+      @api_prefix = '/api/v1'
+      @groups_api = "#{@api_prefix}/groups"
+      @systems_api = "#{@api_prefix}/systems"
+
       ssl_options = {
         :verify => options.fetch(:verify_ssl) { OpenSSL::SSL::VERIFY_PEER }
       }
@@ -29,6 +34,7 @@ module Papertrail
       @connection = Faraday::Connection.new(:url => 'https://papertrailapp.com', :ssl => ssl_options) do |builder|
         builder.adapter Faraday.default_adapter
         builder.use Faraday::Response::RaiseError
+        builder.use Faraday::Request::UrlEncoded
         builder.use FaradayMiddleware::ParseJson, :content_type => /\bjson$/
       end.tap do |conn|
         if options[:username] && options[:password]
@@ -47,7 +53,6 @@ module Papertrail
 
     def find_id_for_group(name)
       response = @connection.get('/api/v1/groups.json')
-
       find_id_for_item(response.body, name)
     end
 
@@ -58,6 +63,60 @@ module Papertrail
 
       items.each do |item|
         return item['id'] if item['name'] =~ /#{Regexp.escape(name_wanted)}/i
+      end
+      return nil
+    end
+
+    def create_group(name, system_wildcard = nil)
+      group = { :group => { :name => name } }
+      if (system_wildcard)
+        group[:group][:system_wildcard] = system_wildcard
+      end
+      group_query = Addressable::URI.new
+      group_query.query_values = group
+      response = @connection.post("#{@groups_api}.json", group_query.query)
+      return response.status == 200
+    end
+
+    def show_group(name)
+      id = find_id_for_group(name)
+      if (id)
+        response = @connection.get("#{@groups_api}/#{id}.json")
+        return response.body
+      end
+    end
+
+    def show_source(name)
+      id = find_id_for_source(name)
+      if (id)
+        response = @connection.get("#{@systems_api}/#{id}.json")
+        return response.body
+      end
+    end
+
+    def join_group(source_name, group_name)
+      source_id = find_id_for_source(source_name)
+      group_id = find_id_for_group(group_name)
+      if (source_id && group_id)
+        group_query = Addressable::URI.new
+        group_query.query_values = { :group_id => group_id }
+        response = @connection.post("#{@systems_api}/#{source_id}/join.json", group_query.query)
+        return response.status == 200
+      end
+    end
+
+    def register_source(name, ip_address)
+      system_query = Addressable::URI.new
+      system_query.query_values = { :system => { :name => name, :ip_address => ip_address } }
+      response = @connection.post("#{@systems_api}.json", system_query.query)
+      return response.status == 200
+    end
+
+    def unregister_source(name)
+      source_id = find_id_for_source(name)
+      if (source_id)
+        response = @connection.delete("#{@systems_api}/#{source_id}.json")
+        return response.status == 200
       end
     end
 

--- a/papertrail.gemspec
+++ b/papertrail.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   ## the sub! line in the Rakefile
   s.name              = 'papertrail'
   s.version           = '0.9.2'
-  s.date              = '2012-05-02'
+  s.date              = '2012-07-10'
   s.rubyforge_project = 'papertrail'
 
   ## Make sure your summary is short. The description may be as long
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
 #  s.extensions = %w[ext/extconf.rb]
 
   ## If your gem includes any executables, list them here.
-  s.executables = ["papertrail"]
+  s.executables = ["papertrail", "papertrail-add-system", "papertrail-remove-system", "papertrail-add-group", "papertrail-join-group"]
   s.default_executable = 'papertrail'
 
   ## Specify any RDoc options here. You'll want to add your README and
@@ -49,6 +49,7 @@ Gem::Specification.new do |s|
 
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
+  s.add_dependency('addressable')
   s.add_dependency('yajl-ruby')
   s.add_dependency('faraday', [ '>= 0.6', '< 0.9' ])
   s.add_dependency('faraday_middleware', [ '~> 0.8.4' ])
@@ -67,9 +68,17 @@ Gem::Specification.new do |s|
     README.md
     Rakefile
     bin/papertrail
+    bin/papertrail-add-group
+    bin/papertrail-add-system
+    bin/papertrail-join-group
+    bin/papertrail-remove-system
     examples/papertrail.yml.example
     lib/papertrail.rb
     lib/papertrail/cli.rb
+    lib/papertrail/cli_add_group.rb
+    lib/papertrail/cli_add_system.rb
+    lib/papertrail/cli_join_group.rb
+    lib/papertrail/cli_remove_system.rb
     lib/papertrail/connection.rb
     lib/papertrail/event.rb
     lib/papertrail/search_query.rb


### PR DESCRIPTION
In order to be able to use the Papertrail API in an automated fashion, I added support for more of the HTTP API (e.g., adding systems and groups). I didn't cover the entire API, but it works as a starting point for my needs. Feel free to modify as you see fit.
