### PR TITLE
Catch exceptions when attempting to get default config file

### DIFF
--- a/lib/papertrail/cli_helpers.rb
+++ b/lib/papertrail/cli_helpers.rb
@@ -1,11 +1,14 @@
 module Papertrail
   module CliHelpers
     def find_configfile
-      if File.exists?(path = File.expand_path('.papertrail.yml'))
-        return path
-      end
-      if File.exists?(path = File.expand_path('~/.papertrail.yml'))
-        return path
+      begin
+        if File.exists?(path = File.expand_path('.papertrail.yml'))
+          return path
+        end
+        if File.exists?(path = File.expand_path('~/.papertrail.yml'))
+          return path
+        end
+      rescue
       end
     end
 


### PR DESCRIPTION
For example if the HOME environment variable is not set, you will get
something like this:

couldn't find HOME environment -- expanding `~/.papertrail.yml'
