### PR TITLE
Support API token in PAPERTRAIL_API_TOKEN environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ invoke the corresponding Papertrail [HTTP API] call.
     $ echo "token: 123456789012345678901234567890ab" > ~/.papertrail.yml
     $ papertrail
 
-Retrieve token from Papertrail [User Profile].
+Retrieve the token from Papertrail [User Profile].
+
+The API token can also be passed in the `PAPERTRAIL_API_TOKEN`
+environment variable instead of a configuration file. Example:
+
+    $ export PAPERTRAIL_API_TOKEN='abc123'
+    $ papertrail
 
 
 ## Installation

--- a/lib/papertrail/cli.rb
+++ b/lib/papertrail/cli.rb
@@ -15,7 +15,8 @@ module Papertrail
       @options = {
         :configfile => nil,
         :delay  => 2,
-        :follow => false
+        :follow => false,
+        :token  => ENV['PAPERTRAIL_API_TOKEN']
       }
 
       @query_options = {}


### PR DESCRIPTION
Hat tip to @dpehrson for suggesting this.
