### PR TITLE
Support PAPERTRAIL_API_TOKEN ENV var for all cli commands

### DIFF
--- a/lib/papertrail/cli_add_group.rb
+++ b/lib/papertrail/cli_add_group.rb
@@ -11,6 +11,7 @@ module Papertrail
     def run
       options = {
         :configfile => nil,
+        :token => ENV['PAPERTRAIL_API_TOKEN'],
       }
 
       if configfile = find_configfile

--- a/lib/papertrail/cli_add_system.rb
+++ b/lib/papertrail/cli_add_system.rb
@@ -13,6 +13,7 @@ module Papertrail
     def run
       options = {
         :configfile => nil,
+        :token => ENV['PAPERTRAIL_API_TOKEN'],
       }
 
       if configfile = find_configfile

--- a/lib/papertrail/cli_join_group.rb
+++ b/lib/papertrail/cli_join_group.rb
@@ -11,6 +11,7 @@ module Papertrail
     def run
       options = {
         :configfile => nil,
+        :token => ENV['PAPERTRAIL_API_TOKEN'],
       }
 
       if configfile = find_configfile

--- a/lib/papertrail/cli_remove_system.rb
+++ b/lib/papertrail/cli_remove_system.rb
@@ -11,6 +11,7 @@ module Papertrail
     def run
       options = {
         :configfile => nil,
+        :token => ENV['PAPERTRAIL_API_TOKEN'],
       }
 
       if configfile = find_configfile


### PR DESCRIPTION
This pull request updates all commands to accept the PAPERTRAIL_API_TOKEN environment variable, previously it only worked with the 'papertrail' command, other commands such as 'papertrail-add-group' would only work if the config file was present.
