### PR TITLE
Added note to README.md for Mac OSX .bashrc mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ invoke `pt` with optional search operators:
 
 Add the function line to your `~/.bashrc`.
 
+NOTE: On Mac OSX `~/.bashrc` you might have to format the function like this and change $_ to $* for it to work:
+```
+    function pt() 
+    { 
+	    echo "$* is the search"
+	    papertrail -f -d 5 $* | colortail -g papertrail 
+    }
+```
+
 ### Advanced
 
 For complete control, pipe through anything capable of inserting ANSI


### PR DESCRIPTION
When I tried to use the instructions in the readme I was getting end of line errors (because of the pt() function as oneliner), as well as seeing CLI params not being passed to the function.

$_ is not correct - it saves the parameter for the next invocation, $\* is the correct parameter designator to pass all arguments as string.

see: http://tldp.org/LDP/abs/html/internalvariables.html#POSPARAMREF
