### PR TITLE
Fixes Encoding::CompatibilityError

### DIFF
--- a/lib/papertrail/http_client.rb
+++ b/lib/papertrail/http_client.rb
@@ -13,7 +13,7 @@ module Papertrail
     end
 
     def body
-      @body ||= Papertrail::OkJson.decode(__getobj__.body)
+      @body ||= Papertrail::OkJson.decode(__getobj__.body.dup.force_encoding('UTF-8'))
     end
 
   end


### PR DESCRIPTION
Avoids:

```
/home/leon/.rvm/gems/ruby-2.0.0-p0/gems/papertrail-0.9.8/lib/papertrail/okjson.rb:361:in `[]=': incompatible character encodings: UTF-8 and ASCII-8BIT (Encoding::CompatibilityError)
    from /home/leon/.rvm/gems/ruby-2.0.0-p0/gems/papertrail-0.9.8/lib/papertrail/okjson.rb:361:in `unquote'
    from /home/leon/.rvm/gems/ruby-2.0.0-p0/gems/papertrail-0.9.8/lib/papertrail/okjson.rb:285:in `strtok'
    from /home/leon/.rvm/gems/ruby-2.0.0-p0/gems/papertrail-0.9.8/lib/papertrail/okjson.rb:251:in `tok'
    from /home/leon/.rvm/gems/ruby-2.0.0-p0/gems/papertrail-0.9.8/lib/papertrail/okjson.rb:214:in `lex'
    from /home/leon/.rvm/gems/ruby-2.0.0-p0/gems/papertrail-0.9.8/lib/papertrail/okjson.rb:45:in `decode'
    from /home/leon/.rvm/gems/ruby-2.0.0-p0/gems/papertrail-0.9.8/lib/papertrail/http_client.rb:16:in `body'
    from /home/leon/.rvm/gems/ruby-2.0.0-p0/gems/papertrail-0.9.8/lib/papertrail/search_query.rb:17:in `search'
    from /home/leon/.rvm/gems/ruby-2.0.0-p0/gems/papertrail-0.9.8/lib/papertrail/cli.rb:110:in `query_time_range'
    from /home/leon/.rvm/gems/ruby-2.0.0-p0/gems/papertrail-0.9.8/lib/papertrail/cli.rb:95:in `run'
    from /home/leon/.rvm/gems/ruby-2.0.0-p0/gems/papertrail-0.9.8/bin/papertrail:5:in `<top (required)>'
    from /home/leon/.rvm/gems/ruby-2.0.0-p0/bin/papertrail:19:in `load'
    from /home/leon/.rvm/gems/ruby-2.0.0-p0/bin/papertrail:19:in `<main>'
    from /home/leon/.rvm/gems/ruby-2.0.0-p0/bin/ruby_executable_hooks:15:in `eval'
    from /home/leon/.rvm/gems/ruby-2.0.0-p0/bin/ruby_executable_hooks:15:in `<main>'
```
