### PR TITLE
Add -S and --search to specify a named saved search

### DIFF
--- a/lib/papertrail/cli.rb
+++ b/lib/papertrail/cli.rb
@@ -89,7 +89,7 @@ module Papertrail
       end
 
       if options[:search]
-        search = connection.find_search(options[:search])
+        search = connection.find_search(options[:search], query_options[:group_id])
         unless search
           abort "Search \"#{options[:search]}\" not found"
         end

--- a/lib/papertrail/connection.rb
+++ b/lib/papertrail/connection.rb
@@ -49,21 +49,33 @@ module Papertrail
       find_id_for_item(response.body, name)
     end
 
-    def find_search(name)
+    def find_search(name, group_id = nil)
       response = @connection.get('searches.json')
 
-      find_item_by_name(response.body, name)
+      candidates = find_item_by_name(response.body, name)
+      return nil if candidates.empty?
+
+      candidates.each do |item|
+        if !group_id || group_id == item['group_id']
+          return item
+        end
+      end
+
+      return candidates.first
     end
 
-    def find_item_by_name(items, name_wanted)
+    def find_items_by_name(items, name_wanted)
+      results = []
+
       items.each do |item|
-        return item if item['name'] == name_wanted
+        results << item if item['name'] == name_wanted
       end
 
       items.each do |item|
-        return item if item['name'] =~ /#{Regexp.escape(name_wanted)}/i
+        results << item if item['name'] =~ /#{Regexp.escape(name_wanted)}/i
       end
-      return nil
+      
+      results
     end
 
     def find_id_for_item(items, name_wanted)


### PR DESCRIPTION
Accept the name of a saved search. Works logically in all forms:
- When only a search is specified, use the search and group to which it is attached
- When a search and a group are both provided, use the user-supplied group (so that one search can be applied to a different group)
- When a search and a group are both provided, prefer searches within that group (to disambiguate between searches of the same name in different groups)
