### PR TITLE
-j fails on Yosemite 

### DIFF
--- a/lib/papertrail/cli.rb
+++ b/lib/papertrail/cli.rb
@@ -4,6 +4,7 @@ require 'chronic'
 
 require 'papertrail/connection'
 require 'papertrail/cli_helpers'
+require 'papertrail/okjson'
 
 module Papertrail
   class Cli
@@ -137,7 +138,7 @@ module Papertrail
           end
 
           if options[:json]
-            $stdout.puts event.data.to_json
+            $stdout.puts Papertrail::OkJson.encode(event.data)
           else
             $stdout.puts event
           end
@@ -159,7 +160,7 @@ module Papertrail
 
     def display_results(results)
       if options[:json]
-        $stdout.puts results.data.to_json
+        $stdout.puts Papertrail::OkJson.encode(results.data)
       else
         results.events.each do |event|
           $stdout.puts event


### PR DESCRIPTION
```
$ papertrail -j "program:simplepaas-nginx -wp-cron GET myimage"
/Library/Ruby/Gems/2.0.0/gems/papertrail-0.9.10/lib/papertrail/cli.rb:162:in `display_results': undefined method `to_json' for #<Hash:0x007fd1c4263ca0> (NoMethodError)
    from /Library/Ruby/Gems/2.0.0/gems/papertrail-0.9.10/lib/papertrail/cli.rb:119:in `run'
    from /Library/Ruby/Gems/2.0.0/gems/papertrail-0.9.10/bin/papertrail:5:in `<top (required)>'
    from /usr/bin/papertrail:23:in `load'
    from /usr/bin/papertrail:23:in `<main>'
$
```

```
$ sw_vers 
ProductName:    Mac OS X
ProductVersion: 10.10.1
BuildVersion:   14B17
```
