### PR TITLE
Exit when stdout closed

### DIFF
--- a/bin/papertrail
+++ b/bin/papertrail
@@ -3,6 +3,6 @@ require 'papertrail/cli'
 
 begin
   Papertrail::Cli.new.run
-rescue Interrupt
+rescue Interrupt, Errno::EPIPE
   exit(0)
 end

--- a/lib/papertrail/cli.rb
+++ b/lib/papertrail/cli.rb
@@ -29,6 +29,10 @@ module Papertrail
     end
 
     def run
+      # Exit when downstream program closes pipe. For example:
+      #   $ papertrail | head -n 2
+      Signal.trap('PIPE') { exit }
+
       if configfile = find_configfile
         configfile_options = load_configfile(configfile)
         options.merge!(configfile_options)

--- a/lib/papertrail/cli.rb
+++ b/lib/papertrail/cli.rb
@@ -29,10 +29,6 @@ module Papertrail
     end
 
     def run
-      # Exit when downstream program closes pipe. For example:
-      #   $ papertrail | head -n 2
-      Signal.trap('PIPE') { exit }
-
       if configfile = find_configfile
         configfile_options = load_configfile(configfile)
         options.merge!(configfile_options)


### PR DESCRIPTION
When piping `papertrail` to another program, the downstream program can close the pipe and we need to exit cleanly. It seems this can be resolved either by trapping `PIPE` or rescuing `Errno::EPIPE` (likely in `Papertrail::Cli#run`). Opted for the former but I have no preference.

closes #73