### PR TITLE
Allow quoteless query

### DIFF
--- a/lib/papertrail/cli.rb
+++ b/lib/papertrail/cli.rb
@@ -120,7 +120,7 @@ module Papertrail
         @query = search['query']
       end
 
-      @query ||= ARGV[0]
+      @query ||= ARGV.join ' '
 
       if options[:follow]
         search_query = connection.query(@query, query_options)


### PR DESCRIPTION
Following a short discussion I had with Mark on the subject, wanted to see if this actually works.

This tiny PR allows running
```
$ papertrail any search string
```
In addition to the quoted version already available:
```
$ papertrail "any search string"
```

There are no tests, so it is hard for me to see if this breaks anything, but I believe this is backwards compatible and only adds a nice functionality.
