### PR TITLE
Friendly (traceless) error messages

### DIFF
--- a/lib/papertrail/cli.rb
+++ b/lib/papertrail/cli.rb
@@ -122,20 +122,26 @@ module Papertrail
 
       @query ||= ARGV[0]
 
-      if options[:follow]
-        search_query = connection.query(@query, query_options)
+      begin
+        if options[:follow]
+          search_query = connection.query(@query, query_options)
 
-        loop do
+          loop do
+            display_results(search_query.search)
+            sleep options[:delay]
+          end
+        elsif options[:min_time]
+          query_time_range
+        else
+          set_min_max_time!(options, query_options)
+          search_query = connection.query(@query, query_options)
           display_results(search_query.search)
-          sleep options[:delay]
-        end
-      elsif options[:min_time]
-        query_time_range
-      else
-        set_min_max_time!(options, query_options)
-        search_query = connection.query(@query, query_options)
-        display_results(search_query.search)
+        end      
+      rescue ArgumentError => e
+        $stderr.puts "Argument Error: #{e.message}"
+        exit 1
       end
+
     end
 
     def query_time_range

--- a/lib/papertrail/cli.rb
+++ b/lib/papertrail/cli.rb
@@ -34,7 +34,7 @@ module Papertrail
         options.merge!(configfile_options)
       end
 
-      OptionParser.new do |opts|
+      option_parser = OptionParser.new do |opts|
         opts.banner  = "papertrail - command-line tail and search for Papertrail log management service"
         opts.version = Papertrail::VERSION
 
@@ -83,7 +83,14 @@ module Papertrail
         end
 
         opts.separator usage
-      end.parse!
+      end
+
+      begin
+        option_parser.parse!
+      rescue OptionParser::InvalidOption => e
+        $stderr.puts e.message
+        exit 1
+      end        
 
       if options[:configfile]
         configfile_options = load_configfile(options[:configfile])


### PR DESCRIPTION
This PR comes to improve error messages by showing only the message, and not the trace.

It rescues two exceptions:
- `ArgumentError` - raised in some cases across the code, for example - when providing an invalid argument to `--min-time`
- `OptionParser::InvalidOption` - which is raised when parsing unexpected option
- Closes #61 

After merging, you get these:

```
$ papertrail --min-time asd
Argument Error: Could not parse time string 'asd'

 $ papertrail --asd
invalid option: --asd
```


