### PR TITLE
GPA Improvements: 1.15 to 2.02

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,7 +6,6 @@ engines:
       languages:
       - ruby
 
-
   fixme:
     enabled: true
 
@@ -15,8 +14,7 @@ engines:
 
 ratings:
   paths:
-
   - "**.rb"
 
 exclude_paths: 
-  - lib/papertrail/okjson.rb
+- lib/papertrail/okjson.rb

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,22 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+
+
+  fixme:
+    enabled: true
+
+  rubocop:
+    enabled: true
+
+ratings:
+  paths:
+
+  - "**.rb"
+
+exclude_paths: 
+  - lib/papertrail/okjson.rb

--- a/Rakefile
+++ b/Rakefile
@@ -115,7 +115,7 @@ desc "Generate #{gemspec_file}"
 task :gemspec => :validate do
   # read spec file and split out manifest section
   spec = File.read(gemspec_file)
-  head, manifest, tail = spec.split("  # = MANIFEST =\n")
+  head, _manifest, tail = spec.split("  # = MANIFEST =\n")
 
   # replace name version and date
   replace_header(head, :name)

--- a/lib/papertrail/cli.rb
+++ b/lib/papertrail/cli.rb
@@ -29,7 +29,7 @@ module Papertrail
     end
 
     def run
-      if configfile = find_configfile
+      if configfile
         configfile_options = load_configfile(configfile)
         options.merge!(configfile_options)
       end
@@ -38,11 +38,11 @@ module Papertrail
         opts.banner  = "papertrail - command-line tail and search for Papertrail log management service"
         opts.version = Papertrail::VERSION
 
-        opts.on("-h", "--help", "Show usage") do |v|
+        opts.on("-h", "--help", "Show usage") do
           puts opts
           exit
         end
-        opts.on("-f", "--follow", "Continue running and printing new events (off)") do |v|
+        opts.on("-f", "--follow", "Continue running and printing new events (off)") do
           options[:follow] = true
         end
         opts.on("--min-time MIN", "Earliest time to search from") do |v|
@@ -66,15 +66,15 @@ module Papertrail
         opts.on("-s", "--system SYSTEM", "System to search") do |v|
           options[:system] = v
         end
-        opts.on("-j", "--json", "Output raw JSON data (off)") do |v|
+        opts.on("-j", "--json", "Output raw JSON data (off)") do
           options[:json] = true
         end
-        opts.on("--color [program|system|all|off]",
-                [:program, :system, :all, :off],
-                "Attribute(s) to colorize based on (program)") do |v|
+        opts.on("--color [program|system|all|off]", 
+          [:program, :system, :all, :off], "Attribute(s) to colorize based on (program)") do |v|
+
           options[:color] = v
         end
-        opts.on("--force-color", "Force use of ANSI color characters even on non-tty outputs (off)") do |v|
+        opts.on("--force-color", "Force use of ANSI color characters even on non-tty outputs (off)") do
           options[:force_color] = true
         end
         opts.on("-V", "--version", "Display the version and exit") do |v|

--- a/lib/papertrail/cli_add_group.rb
+++ b/lib/papertrail/cli_add_group.rb
@@ -14,7 +14,7 @@ module Papertrail
         :token => ENV['PAPERTRAIL_API_TOKEN'],
       }
 
-      if configfile = find_configfile
+      if configfile
         configfile_options = load_configfile(configfile)
         options.merge!(configfile_options)
       end
@@ -22,7 +22,7 @@ module Papertrail
       OptionParser.new do |opts|
         opts.banner = "papertrail-add-group"
 
-        opts.on("-h", "--help", "Show usage") do |v|
+        opts.on("-h", "--help", "Show usage") do
           puts opts
           exit
         end

--- a/lib/papertrail/cli_add_system.rb
+++ b/lib/papertrail/cli_add_system.rb
@@ -16,7 +16,7 @@ module Papertrail
         :token => ENV['PAPERTRAIL_API_TOKEN'],
       }
 
-      if configfile = find_configfile
+      if configfile
         configfile_options = load_configfile(configfile)
         options.merge!(configfile_options)
       end
@@ -59,7 +59,7 @@ module Papertrail
         opts.separator ''
         opts.separator "Common options:"
 
-        opts.on("-h", "--help", "Show usage") do |v|
+        opts.on("-h", "--help", "Show usage") do
           puts opts
           exit
         end

--- a/lib/papertrail/cli_helpers.rb
+++ b/lib/papertrail/cli_helpers.rb
@@ -1,10 +1,14 @@
 module Papertrail
   module CliHelpers
+    def configfile
+      @configfile ||= find_configfile
+    end
+
     def find_configfile
-      if File.exists?(path = File.expand_path('.papertrail.yml'))
+      if File.exist?(path = File.expand_path('.papertrail.yml'))
         return path
       end
-      if File.exists?(path = File.expand_path('~/.papertrail.yml'))
+      if File.exist?(path = File.expand_path('~/.papertrail.yml'))
         return path
       end
     rescue ArgumentError

--- a/lib/papertrail/cli_join_group.rb
+++ b/lib/papertrail/cli_join_group.rb
@@ -14,7 +14,7 @@ module Papertrail
         :token => ENV['PAPERTRAIL_API_TOKEN'],
       }
 
-      if configfile = find_configfile
+      if configfile
         configfile_options = load_configfile(configfile)
         options.merge!(configfile_options)
       end

--- a/lib/papertrail/cli_leave_group.rb
+++ b/lib/papertrail/cli_leave_group.rb
@@ -14,7 +14,7 @@ module Papertrail
         :token => ENV['PAPERTRAIL_API_TOKEN'],
       }
 
-      if configfile = find_configfile
+      if configfile
         configfile_options = load_configfile(configfile)
         options.merge!(configfile_options)
       end

--- a/lib/papertrail/cli_remove_system.rb
+++ b/lib/papertrail/cli_remove_system.rb
@@ -14,7 +14,7 @@ module Papertrail
         :token => ENV['PAPERTRAIL_API_TOKEN'],
       }
 
-      if configfile = find_configfile
+      if configfile
         configfile_options = load_configfile(configfile)
         options.merge!(configfile_options)
       end


### PR DESCRIPTION
An assortment of small to medium changes to improve code standards:

1. Exclude `okjson` from Code Climate
2. Remove / rename unused variables, mostly in the `OptionsParser` blocks
3. Add `configfile` method to `CliHelpers` to avoid repeating the confusing condition+assignment `if configfile = find_configfile`
4. Reduce code duplication in `http_client` by adding an `attempt times, wait, &block` method to handle HTTP retries in a single place.

CC: #78 
