### PR TITLE
Adds wrapper binary for adding users to an organization

### DIFF
--- a/bin/papertrail-add-user
+++ b/bin/papertrail-add-user
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+require 'papertrail/cli_add_user'
+
+begin
+  Papertrail::CliAddUser.new.run
+rescue Interrupt
+  exit(0)
+end

--- a/lib/papertrail.rb
+++ b/lib/papertrail.rb
@@ -1,5 +1,5 @@
 module Papertrail
-  VERSION = "0.9.17"
+  VERSION = "0.10.0"
 end
 
 require 'papertrail/connection'

--- a/lib/papertrail/cli_add_user.rb
+++ b/lib/papertrail/cli_add_user.rb
@@ -1,0 +1,78 @@
+require 'optparse'
+require 'yaml'
+
+require 'papertrail/cli_helpers'
+require 'papertrail/connection'
+
+module Papertrail
+  class CliAddUser
+    include Papertrail::CliHelpers
+
+    def run
+      options = {
+        :configfile => nil,
+        :token => ENV['PAPERTRAIL_API_TOKEN'],
+        :read_only => 1,
+      }
+
+      if configfile = find_configfile
+        configfile_options = load_configfile(configfile)
+        options.merge!(configfile_options)
+      end
+
+      OptionParser.new do |opts|
+        opts.banner = "papertrail-add-user"
+
+        opts.on("-h", "--help", "Show usage") do |v|
+          puts opts
+          exit
+        end
+        opts.on("-c", "--configfile PATH", "Path to config (~/.papertrail.yml)") do |v|
+          options[:configfile] = File.expand_path(v)
+        end
+        opts.on("-e", "--email EMAIL", "Email address of user to add") do |v|
+          options[:email] = v
+        end
+        opts.on("--admin", "Add the user with full access") do |v|
+          options[:read_only] = 0
+        end
+
+        opts.separator usage
+      end.parse!
+
+      if options[:configfile]
+        configfile_options = load_configfile(options[:configfile])
+        options.merge!(configfile_options)
+      end
+
+      raise OptionParser::MissingArgument, 'email' if options[:email].nil?
+
+      connection = Papertrail::Connection.new(options)
+
+      if connection.add_user(options[:email], options[:read_only])
+        exit 0
+      end
+
+      exit 1
+    rescue OptionParser::ParseError => e
+      puts "Error: #{e}"
+      puts usage
+      exit 1
+    rescue Net::HTTPServerException => e
+      output_http_error(e)
+      exit 1
+    end
+
+        def usage
+      <<-EOF
+
+  Usage:
+    papertrail-add-user [-e email] [--admin] [-c papertrail.yml]
+
+  Example:
+    papertrail-add-user -e foo@example.com --admin
+
+  EOF
+    end
+  end
+end

--- a/lib/papertrail/connection.rb
+++ b/lib/papertrail/connection.rb
@@ -91,6 +91,11 @@ module Papertrail
       return nil
     end
 
+    def add_user(email, read_only = 1)
+      user = { :user => { :email => email, :read_only => read_only } }
+      @connection.post("users/invite.json", user)
+    end
+
     def create_group(name, system_wildcard = nil)
       group = { :group => { :name => name } }
       if system_wildcard

--- a/papertrail.gemspec
+++ b/papertrail.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   ## If your rubyforge_project name is different, then edit it and comment out
   ## the sub! line in the Rakefile
   s.name              = 'papertrail'
-  s.version           = '0.9.17'
-  s.date              = '2016-09-20'
+  s.version           = '0.10.0'
+  s.date              = '2016-10-11'
   s.rubyforge_project = 'papertrail'
 
   ## Make sure your summary is short. The description may be as long
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
 #  s.extensions = %w[ext/extconf.rb]
 
   ## If your gem includes any executables, list them here.
-  s.executables = ["papertrail", "papertrail-add-system", "papertrail-remove-system", "papertrail-add-group", "papertrail-join-group", "papertrail-leave-group"]
+  s.executables = ["papertrail", "papertrail-add-system", "papertrail-remove-system", "papertrail-add-group", "papertrail-join-group", "papertrail-leave-group", "papertrail-add-user"]
   s.default_executable = 'papertrail'
 
   ## Specify any RDoc options here. You'll want to add your README and
@@ -69,6 +69,7 @@ Gem::Specification.new do |s|
     bin/papertrail
     bin/papertrail-add-group
     bin/papertrail-add-system
+    bin/papertrail-add-user
     bin/papertrail-join-group
     bin/papertrail-leave-group
     bin/papertrail-remove-system
@@ -77,6 +78,7 @@ Gem::Specification.new do |s|
     lib/papertrail/cli.rb
     lib/papertrail/cli_add_group.rb
     lib/papertrail/cli_add_system.rb
+    lib/papertrail/cli_add_user.rb
     lib/papertrail/cli_helpers.rb
     lib/papertrail/cli_join_group.rb
     lib/papertrail/cli_leave_group.rb


### PR DESCRIPTION
Accomplished easily enough with a `curl` but I thought it'd be nice to be able to do this from the CLI/Ruby class as well. An example use case might be using the class itself (or even shelling out w/ less room for error than w/ `curl`) via a Lita bot add someone to Papertrail.

I tried to mimc the style of the rest of the code, but let me know if there's anything you'd like to see done differently. Thanks in advance!
