### PR TITLE
Stop using okjson

### DIFF
--- a/lib/papertrail/cli.rb
+++ b/lib/papertrail/cli.rb
@@ -195,7 +195,6 @@ module Papertrail
 
     if RUBY_VERSION < '1.9'
       # Ruby 1.8 doesn't have json in the standard lib - so we have to use okjson
-      # This is really slow. Avoid it if possible (by upgrading ruby)
       require 'papertrail/okjson'
 
       def output_raw_json(hash)

--- a/lib/papertrail/cli.rb
+++ b/lib/papertrail/cli.rb
@@ -6,12 +6,6 @@ require 'ansi/core'
 require 'papertrail'
 require 'papertrail/connection'
 require 'papertrail/cli_helpers'
-if RUBY_VERSION < '1.9'
-  # Ruby 1.8 doesn't have json in the standard lib - so we have to use okjson
-  require 'papertrail/okjson'
-else
-  require 'json'
-end
 
 module Papertrail
   class Cli
@@ -199,11 +193,18 @@ module Papertrail
       $stdout.flush
     end
 
-    def output_raw_json(hash)
-      if RUBY_VERSION < '1.9'
-        # Ruby 1.8 doesn't have json in the standard lib - so we have to use okjson, which is slow
+    if RUBY_VERSION < '1.9'
+      # Ruby 1.8 doesn't have json in the standard lib - so we have to use okjson
+      # This is really slow. Avoid it if possible (by upgrading ruby)
+      require 'papertrail/okjson'
+
+      def output_raw_json(hash)
         $stdout.puts Papertrail::OkJson.encode(hash)
-      else
+      end
+    else
+      require 'json'
+
+      def output_raw_json(hash)
         $stdout.puts JSON.generate(hash)
       end
     end

--- a/lib/papertrail/http_client.rb
+++ b/lib/papertrail/http_client.rb
@@ -1,6 +1,11 @@
 require 'delegate'
 require 'net/https'
-require 'json'
+if RUBY_VERSION < '1.9'
+  # Ruby 1.8 doesn't have json in the standard lib - so we have to use okjson
+  require 'papertrail/okjson'
+else
+  require 'json'
+end
 
 module Papertrail
 
@@ -8,18 +13,12 @@ module Papertrail
   class HttpResponse < SimpleDelegator
 
     def initialize(response)
-      if RUBY_VERSION < '1.9'
-        # Ruby 1.8 doesn't have json in the standard lib - so we have to use okjson
-        require 'papertrail/okjson'
-      else
-        require 'json'
-      end
       super(response)
     end
 
     def body
       if RUBY_VERSION < '1.9'
-        # This is really slow. Avoid it if possible
+        # This is really slow. Avoid it if possible (by upgrading ruby)
         if __getobj__.body.respond_to?(:force_encoding)
           @body ||= Papertrail::OkJson.decode(__getobj__.body.dup.force_encoding('UTF-8'))
         else

--- a/lib/papertrail/http_client.rb
+++ b/lib/papertrail/http_client.rb
@@ -12,7 +12,6 @@ module Papertrail
 
     if RUBY_VERSION < '1.9'
       # Ruby 1.8 doesn't have json in the standard lib - so we have to use okjson
-      # This is really slow. Avoid it if possible (by upgrading ruby)
       require 'papertrail/okjson'
 
       def body

--- a/lib/papertrail/http_client.rb
+++ b/lib/papertrail/http_client.rb
@@ -1,5 +1,6 @@
 require 'delegate'
 require 'net/https'
+require 'json'
 
 require 'papertrail/okjson'
 
@@ -13,11 +14,12 @@ module Papertrail
     end
 
     def body
-      if __getobj__.body.respond_to?(:force_encoding)
-        @body ||= Papertrail::OkJson.decode(__getobj__.body.dup.force_encoding('UTF-8'))
-      else
-        @body ||= Papertrail::OkJson.decode(__getobj__.body.dup)
-      end
+      @body ||= JSON.parse(__getobj__.body.dup)
+      # if __getobj__.body.respond_to?(:force_encoding)
+      #   @body ||= Papertrail::OkJson.decode(__getobj__.body.dup.force_encoding('UTF-8'))
+      # else
+      #   @body ||= Papertrail::OkJson.decode(__getobj__.body.dup)
+      # end
     end
 
   end


### PR DESCRIPTION
ruby 2.2

```
okjson:       16.73s user 0.42s system 84% cpu 20.363 total
              15.22s user 0.28s system 57% cpu 26.961 total
              15.33s user 0.33s system 69% cpu 22.433 total

standard lib: 0.41s user 0.08s system 12% cpu 3.851 total
              0.45s user 0.09s system 10% cpu 5.085 total
              0.47s user 0.11s system 15% cpu 3.750 total
```

ruby 1.9

```
okjson:       41.27s user 1.38s system 95% cpu 44.581 total
              42.45s user 1.37s system 94% cpu 46.576 total
              41.86s user 1.33s system 94% cpu 45.644 total


standard lib: 0.72s user 0.09s system 31% cpu 2.592 total
              0.72s user 0.09s system 29% cpu 2.756 total
              0.71s user 0.09s system 29% cpu 2.736 total
```