### PR TITLE
replace %e with %d in strftime calls so that date fields are separated by just one space

### DIFF
--- a/lib/papertrail/cli.rb
+++ b/lib/papertrail/cli.rb
@@ -166,7 +166,7 @@ module Papertrail
 
       idx = attribs.hash % 5
       color = COLORS[idx]
-      pre  = "#{event.received_at.strftime('%b %e %X')} #{event.data['hostname']} #{event.data['program']}:"
+      pre  = "#{event.received_at.strftime('%b %d %X')} #{event.data['hostname']} #{event.data['program']}:"
       post = " #{event.data['message']}"
       pre.ansi(color) + post
     end

--- a/lib/papertrail/event.rb
+++ b/lib/papertrail/event.rb
@@ -13,7 +13,7 @@ module Papertrail
     end
 
     def to_s
-      "#{received_at.strftime('%b %e %X')} #{data['hostname']} #{data['program']}: #{data['message']}"
+      "#{received_at.strftime('%b %d %X')} #{data['hostname']} #{data['program']}: #{data['message']}"
     end
   end
 end


### PR DESCRIPTION
When running the example `$ papertrail --min-time '1 minute ago' | cut -f 5 -d ' '` from the README on Dec (0)7 2016 in version 0.10.0 of the gem, the returned value was the system name and not the expected program name, which turned out to be due to the lack of a leading zero on the day number (different from the raw API result or the event viewer).

This change resolves that issue so that the fields in the date are consistently separated by one space (improving field number consistency overall).

Example output without the change:
```
Dec  8 09:29:44 agrant-mb apsd: APSMessageStore - Saving database. 
Dec  8 09:29:44 agrant-mb apsd: APSMessageStore - Destroying database. 
```

Example output with the change:
```
Dec 08 09:19:55 agrant-mb mdmclient: ApplePushService: <APSConnection: [hex_id]> Delivering did reconnect apsd 
Dec 08 09:19:55 agrant-mb mdmclient: ApplePushService: <APSConnection: [hex_id]> queuing call to delegate to tolerate setDelegate race 
```

Result of example without the change (returns system name):
```
$ papertrail --min-time '1 minute ago' | cut -f 5 -d ' '
agrant-mb
agrant-mb
agrant-mb
```

Result of example with the change (returns program name as expected):
```
$ papertrail --min-time '1 minute ago' | cut -f 5 -d ' '
taskgated:
taskgated:
taskgated:
taskgated:
taskgated:
```