### PR TITLE
Specify 1.9.2 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - ruby-1.8.7-head
-  - 1.9.2
+  - ruby-1.9.2-p330
   - 1.9.3
   - 2.0
   - 2.1


### PR DESCRIPTION
Travis is failing to find and compile `ruby 1.9.2`, so manually specify version