### PR TITLE
Add CLI option for group id

### DIFF
--- a/lib/papertrail/cli.rb
+++ b/lib/papertrail/cli.rb
@@ -59,6 +59,9 @@ module Papertrail
         opts.on("-g", "--group GROUP", "Group to search") do |v|
           options[:group] = v
         end
+        opts.on("-i", "--group-id GROUPID", "Group id to search") do |v|
+          options[:grpid] = v
+        end
         opts.on("-S", "--search SEARCH", "Saved search to search") do |v|
           options[:search] = v
         end
@@ -102,6 +105,13 @@ module Papertrail
         end
       end
 
+      if options[:grpid]
+        query_options[:group_id] = options[:grpid]
+        unless query_options[:group_id]
+          abort "Group id not found"
+        end
+      end
+        
       if options[:group]
         query_options[:group_id] = connection.find_id_for_group(options[:group])
         unless query_options[:group_id]


### PR DESCRIPTION
Since the group id api query is slow, this allows bypassing the group id lookup. 

The specifics of this PR are simply a suggestion - providing an option to manually specify the group ID however would drastically speed up the time to execute queries. Benchmarking locally I can get results from `papertrail -f` reporting in ~ 2 seconds, where `papertrail -g "XXX" -f` takes ~ 68 seconds. The group id api lookup is taking over 1 min, regardless of which group is chosen.