### PR TITLE
Use improved lookup API for systems, groups, and searches

### DIFF
--- a/lib/papertrail/connection.rb
+++ b/lib/papertrail/connection.rb
@@ -39,18 +39,18 @@ module Papertrail
     end
 
     def find_id_for_source(name)
-      response = @connection.get('systems.json')
+      response = @connection.get('systems.json', :system_name => name)
 
       find_id_for_item(response.body, name)
     end
 
     def find_id_for_group(name)
-      response = @connection.get('groups.json')
+      response = @connection.get('groups.json', :group_name => name)
       find_id_for_item(response.body, name)
     end
 
     def find_search(name, group_id = nil)
-      response = @connection.get('searches.json')
+      response = @connection.get('searches.json', :search_name => name)
 
       candidates = find_items_by_name(response.body, name)
       return nil if candidates.empty?


### PR DESCRIPTION
Use the (currently undocumented) `system_name`, `group_name`, and `search_name` API filtering parameters to speed up system, group, and saved search lookups (particularly for large accounts). The API filtering operates as a case-insensitive substring match, so the [find_items_by_name](https://github.com/papertrail/papertrail-cli/blob/f8a142a0bdd674783312f6bfb804833933a99af5/lib/papertrail/connection.rb#L67-L79) logic is still needed.

No semantic changes, just a speed improvement.