### PR TITLE
Use HTTP Keep-Alive when possible

### DIFF
--- a/lib/papertrail/cli.rb
+++ b/lib/papertrail/cli.rb
@@ -95,6 +95,9 @@ module Papertrail
 
       @connection = Papertrail::Connection.new(options)
 
+      # Use HTTP Keep-Alive unless delay is too long
+      connection.start if options[:delay] < 10
+
       if options[:system]
         query_options[:system_id] = connection.find_id_for_source(options[:system])
         unless query_options[:system_id]

--- a/lib/papertrail/cli_add_group.rb
+++ b/lib/papertrail/cli_add_group.rb
@@ -46,15 +46,15 @@ module Papertrail
 
       raise OptionParser::MissingArgument, 'group' if options[:group].nil?
 
-      connection = Papertrail::Connection.new(options)
+      Papertrail::Connection.new(options).start do |connection|
+        # Bail if group already exists
+        if connection.show_group(options[:group])
+          exit 0
+        end
 
-      # Bail if group already exists
-      if connection.show_group(options[:group])
-        exit 0
-      end
-
-      if connection.create_group(options[:group], options[:wildcard])
-        exit 0
+        if connection.create_group(options[:group], options[:wildcard])
+          exit 0
+        end
       end
 
       exit 1

--- a/lib/papertrail/cli_add_system.rb
+++ b/lib/papertrail/cli_add_system.rb
@@ -84,19 +84,19 @@ module Papertrail
         error 'Either --ip-address or --destination-port most be provided'
       end
 
-      connection = Papertrail::Connection.new(options)
+      Papertrail::Connection.new(options).start do |connection|
+        # Bail if system already exists
+        if connection.show_source(options[:system])
+          exit 0
+        end
 
-      # Bail if system already exists
-      if connection.show_source(options[:system])
-        exit 0
-      end
+        if options[:destination_port] && !options[:hostname]
+          options[:hostname] = options[:system]
+        end
 
-      if options[:destination_port] && !options[:hostname]
-        options[:hostname] = options[:system]
-      end
-
-      if connection.register_source(options[:system], options)
-        exit 0
+        if connection.register_source(options[:system], options)
+          exit 0
+        end
       end
 
       exit 1

--- a/lib/papertrail/connection.rb
+++ b/lib/papertrail/connection.rb
@@ -38,6 +38,19 @@ module Papertrail
       end
     end
 
+    def start
+      if block_given?
+        @connection.start { yield self }
+      else
+        @connection.start
+        self
+      end
+    end
+
+    def finish
+      @connection.finish
+    end
+
     def find_id_for_source(name)
       response = @connection.get('systems.json', :system_name => name)
 

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -4,6 +4,17 @@ class ConnectionTest < Minitest::Test
   let(:connection_options) { { :token => 'dummy' } }
   let(:connection) { Papertrail::Connection.new(connection_options) }
 
+  def test_start_finish
+    assert_same connection, connection.start
+    assert_nil connection.finish
+
+    block_args = nil
+    connection.start {|*args| block_args = args}
+    assert_equal [connection], block_args
+
+    assert_raises { connection.finish }
+  end
+
   def test_each_event
     skip
   end

--- a/test/http_client_test.rb
+++ b/test/http_client_test.rb
@@ -2,7 +2,17 @@ require 'test_helper'
 
 class HttpClientTest < Minitest::Test
   let(:http) { Papertrail::HttpClient.new({}) }
-  describe "http methods" do
+  describe 'http methods' do
+    def test_start_finish
+      assert_same http, http.start
+      assert_nil http.finish
+
+      block_args = nil
+      http.start {|*args| block_args = args}
+      assert_equal [http], block_args
+
+      assert_raises { http.finish }
+    end
 
     def test_cli_version_present_in_http_methods
       return if RUBY_VERSION < '2.0'
@@ -22,7 +32,8 @@ class HttpClientTest < Minitest::Test
       http.delete('some-path')
     end
   end
-  describe "build_nested_query" do
+
+  describe 'build nested query' do
     def test_value_accepts_hash
       assert_equal(http.send(:build_nested_query, {}), "")
       assert_equal(http.send(:build_nested_query, {:a => 1}), "a=1")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 gem "minitest"
 require 'minitest/autorun'
 require 'minitest/pride' # Color!
-require 'mocha/mini_test'
+require 'mocha/minitest'
 unless RUBY_VERSION < '1.9'
   require 'webmock/minitest'
   WebMock.disable_net_connect!


### PR DESCRIPTION
Adds `start` and `finish` methods to `Papertrail::HttpClient` and `Papertrail::Connection`, mimicking [Net::HTTP#start](https://ruby-doc.org/stdlib-2.5.0/libdoc/net/http/rdoc/Net/HTTP.html#method-i-start). I wanted to use Forwardable/def_delegators, but needed a different return or yield value.

Modified any CLI tool that makes multiple API calls, but it's primarily intended for `papertrail -f`. With HTTP Keep-Alive, we can avoid renegotiating a separate TLS connection every two seconds.