### PR TITLE
Don't bail when existing group/system name partially matches

### DIFF
--- a/lib/papertrail/cli_add_group.rb
+++ b/lib/papertrail/cli_add_group.rb
@@ -48,7 +48,8 @@ module Papertrail
 
       Papertrail::Connection.new(options).start do |connection|
         # Bail if group already exists
-        if connection.show_group(options[:group])
+        existing = connection.show_group(options[:group])
+        if existing && existing['name'].upcase == options[:group].upcase
           exit 0
         end
 

--- a/lib/papertrail/cli_add_system.rb
+++ b/lib/papertrail/cli_add_system.rb
@@ -86,7 +86,8 @@ module Papertrail
 
       Papertrail::Connection.new(options).start do |connection|
         # Bail if system already exists
-        if connection.show_source(options[:system])
+        existing = connection.show_source(options[:system])
+        if existing && existing['name'].upcase == options[:system].upcase
           exit 0
         end
 


### PR DESCRIPTION
Currently, running `papertrail-add-group -g 'My Group'` fails if there's already a group called `My Group A`, or anything else that partially matches the new name. This PR updates the logic to require an exact (but still case-insensitive) match before bailing.

Using `.upcase` for the comparisons since that seems to have the best compatibility with various Ruby versions, while getting automatic Unicode support in Ruby 2.4+. Tested both `papertrail-add-group` and `papertrail-add-system` locally to confirm the bug is fixed.