### PR TITLE
fix(cli_helper): use `File.exist?` because `File.exists?` is deleted in ruby-3.2.0

### DIFF
--- a/lib/papertrail/cli_helpers.rb
+++ b/lib/papertrail/cli_helpers.rb
@@ -1,10 +1,10 @@
 module Papertrail
   module CliHelpers
     def find_configfile
-      if File.exists?(path = File.expand_path('.papertrail.yml'))
+      if File.exist?(path = File.expand_path('.papertrail.yml'))
         return path
       end
-      if File.exists?(path = File.expand_path('~/.papertrail.yml'))
+      if File.exist?(path = File.expand_path('~/.papertrail.yml'))
         return path
       end
     rescue ArgumentError


### PR DESCRIPTION
ruby-3.2.0 deletes deprecated method `File.exists?`
All maintained ruby versions support `File.exist?` method.

This gem should use `File.exist?` to support ruby-3.2.