### PR TITLE
Update the link to the gem page on rubygems.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,6 @@ to your enhancement.
 [Connection]: https://github.com/papertrail/papertrail-cli/blob/master/lib/papertrail/connection.rb
 [HTTP API]: http://help.papertrailapp.com/kb/how-it-works/http-api
 [User Profile]: https://papertrailapp.com/account/profile
-[RubyGems]: https://rubygems.org/gems/papertrail-cli
+[RubyGems]: https://rubygems.org/gems/papertrail
 [lnav]: http://lnav.org/
 [escape characters]: http://en.wikipedia.org/wiki/ANSI_escape_code#Colors


### PR DESCRIPTION
The gem was renamed in
https://github.com/papertrail/papertrail-cli/commit/7b8c4818eb8fa1c55be840ba92e26a440e185bc7#diff-288b40bbad16edee345cdfb4fd18cf667b47b862f24d6d6d340ec58ec67009f0